### PR TITLE
set IV after the encryption key to actually use IV in AES-*-GCM algorithms

### DIFF
--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -60,7 +60,6 @@ module Encryptor
         raise ArgumentError.new("iv must be #{cipher.iv_len} bytes or longer") if options[:iv].bytesize < cipher.iv_len
       end
       if options[:iv]
-        cipher.iv = options[:iv]
         if options[:salt].nil?
           # Use a non-salted cipher.
           # This behaviour is retained for backwards compatibility. This mode
@@ -73,6 +72,7 @@ module Encryptor
           # secure) mode of operation.
           cipher.key = OpenSSL::PKCS5.pbkdf2_hmac_sha1(options[:key], options[:salt], options[:hmac_iterations], cipher.key_len)
         end
+        cipher.iv = options[:iv]
       else
         # This is deprecated and needs to be changed.
         cipher.pkcs5_keyivgen(options[:key])

--- a/test/encryptor_test.rb
+++ b/test/encryptor_test.rb
@@ -6,6 +6,7 @@ class EncryptorTest < Minitest::Test
 
   key = SecureRandom.random_bytes(32)
   iv = SecureRandom.random_bytes(16)
+  iv2 = SecureRandom.random_bytes(16)
   salt = SecureRandom.random_bytes(16)
   original_value = SecureRandom.random_bytes(64)
   auth_data = SecureRandom.random_bytes(64)
@@ -79,6 +80,14 @@ class EncryptorTest < Minitest::Test
   end
 
   OpenSSLHelper::AUTHENTICATED_ENCRYPTION_ALGORITHMS.each do |algorithm|
+
+    define_method 'test_should_use_iv_to_initialize_encryption' do
+      encrypted_value_iv1 = Encryptor.encrypt(value: original_value, key: key, iv: iv, salt: salt, algorithm: algorithm)
+      encrypted_value_iv2 = Encryptor.encrypt(value: original_value, key: key, iv: iv2, salt: salt, algorithm: algorithm)
+      refute_equal original_value, encrypted_value_iv1
+      refute_equal original_value, encrypted_value_iv2
+      refute_equal encrypted_value_iv1, encrypted_value_iv2
+    end
 
     define_method 'test_should_use_the_default_authentication_data_if_it_is_not_specified' do
       encrypted_value = Encryptor.encrypt(value: original_value, key: key, iv: iv, salt: salt, algorithm: algorithm)


### PR DESCRIPTION
Hello, 

a stack overflow user noticed a weird behavior when using `attr_encrypted` (see the [SO question and discussion](http://stackoverflow.com/questions/35991551/unique-ivs-producing-identical-ciphertext-using-attr-encrypted)). The problem is that when encrypting with one of the `aes-*-gcm` algorithms while using initialization vector (IV), the **encrypted result is the same for any IV**, i.e. the init. vector is not taken into account at all. This seems to be an important security problem, especially considering that the `aes-256-gcm` is the default encryption algorithm in this gem.

Further investigation showed that the problem is only with the `-gcm` algorithms, other algorithms seem to be OK, which is btw also proved by the `test_should_crypt_with_the_#{algorithm}_algorithm_with_iv` test. Unfortunately this test does not verify the `-gcm` algorithms.

The problem can be fixed simply by setting the IV **after** setting the encryption key (current code sets IV [before setting the key](https://github.com/attr-encrypted/encryptor/blob/master/lib/encryptor.rb#L63)).

It is unclear to me where exactly this problem originates from, but the fact that it affects only the `-gcm` algorithms and not others suggests that it is a bug somewhere in the [OpenSSL library code for `AES-*-GCM` algorithms](https://github.com/openssl/openssl/blob/master/crypto/evp/e_aes.c). I could not find anything related to the order of setting IVs and keys in any documentation.

Anyway, this pull request moves setting the IV after setting the key and adds an accompanying test. This test fails in the current master branch but will run OK after merging. 

It is very unfortunate that the default encryption algorithm is `aes-256-gcm` and **thus the encryption is less secure for everybody who is not using random salt**. A sad thing to note is also that this fix will probably make all these setups undecipherable as suddenly the IV would be taken into account after upgrading this gem.

**Testing the issue:**

Tested under ruby 2.3.0 compiled against OpenSSL version "1.0.1f 6 Jan 2014".

    def base64_enc(bytes)
      [bytes].pack("m")
    end

    def test_aes_encr(n, cipher, data, key, iv, iv_before_key = true)
      cipher = OpenSSL::Cipher.new(cipher)
      cipher.encrypt

      if iv_before_key
        cipher.iv = iv
        cipher.key = key
      else
        cipher.key = key
        cipher.iv = iv
      end

      if cipher.name.downcase.end_with?("gcm")
        cipher.auth_data = ""
      end

      result = cipher.update(data)
      result << cipher.final

      puts "#{n} #{cipher.name}, iv #{iv_before_key ? "BEFORE" : "AFTER "} key: " +
               "iv=#{iv}, result=#{base64_enc(result)}"
    end

    def test_encryption
      data = "something private"
      key = "This is a key that is 256 bits!!"

      # control tests using AES-256-CBC
      test_aes_encr(1, "aes-256-cbc", data, key, "aaaabbbbccccdddd", true)
      test_aes_encr(2, "aes-256-cbc", data, key, "eeeeffffgggghhhh", true)
      test_aes_encr(3, "aes-256-cbc", data, key, "aaaabbbbccccdddd", false)
      test_aes_encr(4, "aes-256-cbc", data, key, "eeeeffffgggghhhh", false)

      # failing tests using AES-256-GCM
      test_aes_encr(5, "aes-256-gcm", data, key, "aaaabbbbcccc", true)
      test_aes_encr(6, "aes-256-gcm", data, key, "eeeeffffgggg", true)
      test_aes_encr(7, "aes-256-gcm", data, key, "aaaabbbbcccc", false)
      test_aes_encr(8, "aes-256-gcm", data, key, "eeeeffffgggg", false)
    end

Running the `test_encryption` gives:

    >> test_encryption
    1 AES-256-CBC, iv BEFORE key: iv=aaaabbbbccccdddd, result=4IAGcazRmEUIRDE3ZpEgoS0Nmm1/+nrd5VT2/Xab0WM=
    2 AES-256-CBC, iv BEFORE key: iv=eeeeffffgggghhhh, result=T7um2Wgb2vw1r4uryF3xnBeq+KozuetjKGItfNKurGE=
    3 AES-256-CBC, iv AFTER  key: iv=aaaabbbbccccdddd, result=4IAGcazRmEUIRDE3ZpEgoS0Nmm1/+nrd5VT2/Xab0WM=
    4 AES-256-CBC, iv AFTER  key: iv=eeeeffffgggghhhh, result=T7um2Wgb2vw1r4uryF3xnBeq+KozuetjKGItfNKurGE=

    5 id-aes256-GCM, iv BEFORE key: iv=aaaabbbbcccc, result=Tl/HfkWpwoByeYRz6Mz4yIo=
    6 id-aes256-GCM, iv BEFORE key: iv=eeeeffffgggg, result=Tl/HfkWpwoByeYRz6Mz4yIo=
    7 id-aes256-GCM, iv AFTER  key: iv=aaaabbbbcccc, result=+4Iyn7RSDKimTQi0S3gn58E=
    8 id-aes256-GCM, iv AFTER  key: iv=eeeeffffgggg, result=3m9uEDyb9eh1RD3CuOCmc50=

Test results 1-4 show that for CBC it is irrelevant if IV is set before or after the encryption key and that IV is always taken into account (the results differ for different IVs).

The results 5-8 on the other hand prove that the **encrypted results are the same for two different IVs if IV set before the key**, whereas the results are different when IV set after key.

If you need anything else from me regarding this issue, I'll be happy to help.