### PR TITLE
Documentation/fix readme typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ## 2.0.0 ##
 
 * Added support for MRI 2.1, 2.2, 2.3, and Rubinius. (@saghaulor)
-* Added support for Authenticated Encryption Authentiation Data (AEAD) via aes-###-gcm. (@saghaulor)
+* Added support for Authenticated Encryption with Associated Data (AEAD) via aes-###-gcm. (@saghaulor)
 * Changed the defaults to improve security, aes-256-gcm, IV is required. (@saghaulor)
 * Added key and IV minimum length validations. (@saghaulor)
 * Added insecure_mode option to allow for backwards compatibility for users who didn't use unique IV. (@saghaulor)
@@ -18,7 +18,7 @@
 * Removed support for MRI 1.9.3 and JRuby (until JRuby supports `auth_data=`, https://github.com/jruby/jruby/issues/3376). (@saghaulor)
 * Changed tests to use Minitest. (@saghaulor)
 * Changed syntax to use Ruby 1.9+ hash syntax. (@saghaulor)
-* Salt may be deprecated in a future release, it remains for backwards compatibility. It's better security to have a unique key per record, however, the cost of PKCS5 is too high to force on to users by default. If users want a unique key per record they can implement it in their own way.
+* Salt may be deprecated in a future release, it remains for backwards compatibility. It's more secure to have a unique key per record, however, the cost of PKCS5 is too high to force it on to users by default. If users want a unique key per record they can implement it in their own way.
 
 ## 1.3.0 ##
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A simple wrapper for the standard Ruby OpenSSL library
 
 ## Upgrading from v2.0.0 to v3.0.0 ##
-A bug was discovered in Encryptor 2.0.0 wherein the IV was not being used when using an AES-\*-GCM algorithm. Unfornately fixing this major security issue results in the inability to decrypt records encrypted using an AES-\*-GCM algorithm from Encryptor v2.0.0. While the behavior change is minimal between v2.0.0 and v3.0.0, the change has a significant impact on users that used v2.0.0 and encrypted data using an AES-\*-GCM algorithm, which is the default algorithm for v2.0.0. Consequently, we decided to increment the version with a major bump to help people avoid a confusing situation where some of their data will not decrypt. A new option is available in Encryptor 3.0.0 that allows decryption of data encrypted using an AES-\*-GCM algorithm from Encryptor v2.0.0.
+A bug was discovered in Encryptor 2.0.0 wherein the IV was not being used when using an AES-\*-GCM algorithm. Unfortunately fixing this major security issue results in the inability to decrypt records encrypted using an AES-\*-GCM algorithm from Encryptor v2.0.0. While the behavior change is minimal between v2.0.0 and v3.0.0, the change has a significant impact on users that used v2.0.0 and encrypted data using an AES-\*-GCM algorithm, which is the default algorithm for v2.0.0. Consequently, we decided to increment the version with a major bump to help people avoid a confusing situation where some of their data will not decrypt. A new option is available in Encryptor 3.0.0 that allows decryption of data encrypted using an AES-\*-GCM algorithm from Encryptor v2.0.0.
 
 ### Installation
 
@@ -24,8 +24,8 @@ The best example is:
 ```ruby
 cipher = OpenSSL::Cipher.new('aes-256-gcm')
 cipher.encrypt # Required before '#random_key' or '#random_iv' can be called. http://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/Cipher.html#method-i-encrypt
-secret_key = cipher.random_key # Insures that the key is the correct length respective to the algorithm used.
-iv = cipher.random_iv # Insures that the IV is the correct length respective to the algorithm used.
+secret_key = cipher.random_key # Ensures that the key is the correct length respective to the algorithm used.
+iv = cipher.random_iv # Ensures that the IV is the correct length respective to the algorithm used.
 salt = SecureRandom.random_bytes(16)
 encrypted_value = Encryptor.encrypt(value: 'some string to encrypt', key: secret_key, iv: iv, salt: salt)
 decrypted_value = Encryptor.decrypt(value: encrypted_value, key: secret_key, iv: iv, salt: salt)
@@ -36,7 +36,7 @@ A slightly easier example is:
 ```ruby
 require 'securerandom'
 secret_key = SecureRandom.random_bytes(32) # The length in bytes must be equal to or greater than the algorithm bit length.
-iv = SecureRandom.random_bytes(12) # Recomended length for AES-###-GCM algorithm. https://tools.ietf.org/html/rfc5084#section-3.2
+iv = SecureRandom.random_bytes(12) # Recommended length for AES-###-GCM algorithm. https://tools.ietf.org/html/rfc5084#section-3.2
 encrypted_value = Encryptor.encrypt(value: 'some string to encrypt', key: secret_key, iv: iv)
 decrypted_value = Encryptor.decrypt(value: encrypted_value, key: secret_key, iv: iv)
 ```
@@ -217,4 +217,3 @@ seed-ofb|16|16
 * Add tests for it: this is important so I don't break it in a future version unintentionally.
 * Commit, do not mess with Rakefile, version, or history: if you want to have your own version, that is fine but bump version in a commit by itself I can ignore when I pull).
 * Send me a pull request: bonus points for topic branches.
-

--- a/lib/encryptor.rb
+++ b/lib/encryptor.rb
@@ -6,7 +6,7 @@ module Encryptor
 
   extend self
 
-  # The default options to use when calling the <tt>encrypt</tt> and <tt>decrypt</tt> methods
+  # The default options to use when calling the <tt>encrypt</tt> and <tt>decrypt</tt> methods:
   #
   # Defaults to { algorithm: 'aes-256-gcm',
   #               auth_data: '',
@@ -14,7 +14,7 @@ module Encryptor
   #               hmac_iterations: 2000,
   #               v2_gcm_iv: false }
   #
-  # Run 'openssl list-cipher-commands' in your terminal to view a list all cipher algorithms that are supported on your platform
+  # Run 'openssl list-cipher-commands' in your terminal to view a list all cipher algorithms that are supported on your platform.
   def default_options
     @default_options ||= { algorithm: 'aes-256-gcm',
                            auth_data: '',
@@ -27,7 +27,7 @@ module Encryptor
   #
   # Optionally accepts <tt>:salt</tt>, <tt>:auth_data</tt>, <tt>:algorithm</tt>, <tt>:hmac_iterations</tt>, and <tt>:insecure_mode</tt> options.
   #
-  # Example
+  # Example:
   #
   #   encrypted_value = Encryptor.encrypt(value: 'some string to encrypt', key: 'some secret key', iv: 'some unique value', salt: 'another unique value')
   #   # or
@@ -36,11 +36,11 @@ module Encryptor
     crypt :encrypt, *args, &block
   end
 
-  # Decrypts a <tt>:value</tt> with a specified <tt>:key</tt> and  <tt>:iv</tt>.
+  # Decrypts a <tt>:value</tt> with a specified <tt>:key</tt> and <tt>:iv</tt>.
   #
   # Optionally accepts <tt>:salt</tt>, <tt>:auth_data</tt>, <tt>:algorithm</tt>, <tt>:hmac_iterations</tt>, and <tt>:insecure_mode</tt> options.
   #
-  # Example
+  # Example:
   #
   #   decrypted_value = Encryptor.decrypt(value: 'some encrypted string', key: 'some secret key', iv: 'some unique value', salt: 'another unique value')
   #   # or
@@ -89,7 +89,7 @@ module Encryptor
         else
           value = extract_cipher_text(options[:value])
           cipher.auth_tag = extract_auth_tag(options[:value])
-          # auth_data must be set after auth_tag has been set when decrypting
+          # auth_data must be set after auth_tag has been set when decrypting.
           # See http://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/Cipher.html#method-i-auth_data-3D
           cipher.auth_data = options[:auth_data]
         end


### PR DESCRIPTION
Since I was incapable of contributing in any other meaningful way, I decided to scan through the documentation for improvements. I didn't bother with rewriting whole sentences though, since most of them were pretty clear as is.